### PR TITLE
Add files via upload

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,7 +12,6 @@ const uglify = require('gulp-uglify')
 const runSequence = require('run-sequence')
 const cleanCSS = require('gulp-clean-css')
 const responsive = require('gulp-responsive')
-const del = require('del')
 const fs = require('fs')
 
 // Synchronised browser testing


### PR DESCRIPTION
Remmoved: 
const del = require('del')
Reason:
In building gulp throws an error:
$ gulp
[12:31:47] Requiring external module babel-register
module.js:327
    throw err;
    ^
Error: Cannot find module 'del'

"Error fixed after making changes above"
